### PR TITLE
Removes incorrect ADPCM encoder's block size requirement (to fix MG #6701)

### DIFF
--- a/build/BuildCommon.cs
+++ b/build/BuildCommon.cs
@@ -1,0 +1,20 @@
+﻿namespace BuildScripts;
+
+static class BuildCommon
+{
+    // There is an issue with FFmpeg that causes incompatible reduced quality audio (MGCB medium & low settings)
+    // to be produced for XAudio2 playback. For reference a ticket has been opened at https://trac.ffmpeg.org/ticket/9397#ticket
+    // (samples per block should be a power of 2, however FFmpeg incorrectly forces this requirement on the block size
+    // instead). For now, we'll just patch out the encoder's power of 2 check.
+    public static void FFmpegApplyXAudio2Fix(BuildContext context)
+    {
+        string filePath = "./ffmpeg/libavcodec/adpcmenc.c";
+        List<string> lines = context.FileReadLines(filePath).ToList();
+        int lineNumber = lines.FindIndex(x => x.Contains("av_log(avctx, AV_LOG_ERROR, \"block size must be power of 2\\n\");"));
+        if (lineNumber != -1)
+        {
+            lines.RemoveRange(lineNumber, 2);
+            context.FileWriteLines(filePath, lines.ToArray());
+        }
+    }
+}

--- a/build/BuildLinuxTask.cs
+++ b/build/BuildLinuxTask.cs
@@ -67,10 +67,11 @@ public sealed class BuildLinuxTask : FrostingTask<BuildContext>
         processSettings.Arguments = $"-c \"make install\"";
         context.StartProcess(shellCommandPath, processSettings);
 
-        // Build ffmpeg
+        // Build ffmpeg (with XAudio2 fix)
         processSettings.WorkingDirectory = "./ffmpeg";
         processSettings.Arguments = $"-c \"make distclean\"";
         context.StartProcess(shellCommandPath, processSettings);
+        BuildCommon.FFmpegApplyXAudio2Fix(context);
         processSettings.Arguments = $"-c \"./configure {binDirFlag} {configureFlags}\"";
         context.StartProcess(shellCommandPath, processSettings);
         processSettings.Arguments = $"-c \"make -j{Environment.ProcessorCount}\"";

--- a/build/BuildMacOSTask.cs
+++ b/build/BuildMacOSTask.cs
@@ -108,10 +108,11 @@ public sealed class BuildMacOSTask : FrostingTask<BuildContext>
         processSettings.Arguments = $"-c \"make install\"";
         context.StartProcess(shellCommandPath, processSettings);
 
-        // Build ffmpeg
+        // Build ffmpeg (with XAudio2 fix)
         processSettings.WorkingDirectory = "./ffmpeg";
         processSettings.Arguments = $"-c \"make distclean\"";
         context.StartProcess(shellCommandPath, processSettings);
+        BuildCommon.FFmpegApplyXAudio2Fix(context);
         processSettings.Arguments = $"-c \"./configure {binDirFlag} {configureFlags} {progsSuffixFlag}\"";
         context.StartProcess(shellCommandPath, processSettings);
         processSettings.Arguments = $"-c \"make -j{Environment.ProcessorCount}\"";

--- a/build/BuildWIndowsTask.cs
+++ b/build/BuildWIndowsTask.cs
@@ -82,10 +82,11 @@ public sealed class BuildWindowsTask : FrostingTask<BuildContext>
         processSettings.Arguments = $"-c \"{exports} make install\"";
         context.StartProcess(shellCommandPath, processSettings);
 
-        // Build ffmpeg
+        // Build ffmpeg (with XAudio2 fix)
         processSettings.WorkingDirectory = "./ffmpeg";
         processSettings.Arguments = $"-c \"{exports} make distclean\"";
         context.StartProcess(shellCommandPath, processSettings);
+        BuildCommon.FFmpegApplyXAudio2Fix(context);
         processSettings.Arguments = $"-c \"{exports} ./configure {binDirFlag} {configureFlags}\"";
         context.StartProcess(shellCommandPath, processSettings);
         processSettings.Arguments = $"-c \"{exports} make -j{Environment.ProcessorCount}\"";


### PR DESCRIPTION
Currently FFmpeg produces incompatible reduced quality audio (MGCB medium & low settings) for XAudio2 playback. Basically the samples per block should be a power of 2, however FFmpeg incorrectly forces this requirement on the block size instead). This PR removes the encoder's power of 2 check. A one line change will also be required to the Content Pipeline project afterwards.

Further details can be found here:
https://github.com/MonoGame/MonoGame/issues/6701
https://trac.ffmpeg.org/ticket/9397#ticket

Please note I have only tested this on Windows at the moment.